### PR TITLE
Adds support for :batch_size and :skip kwargs in Mongoex.Base.find_all()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /ebin
 /deps
 erl_crash.dump
+/tmp

--- a/lib/mongoex/base.ex
+++ b/lib/mongoex/base.ex
@@ -55,8 +55,8 @@ defmodule Mongoex.Base do
         end
       end
 
-      def find_all(selector) do
-        {:ok, res} = Mongoex.Server.find_all(table_name,selector)
+      def find_all(selector, options // []) do
+        {:ok, res} = Mongoex.Server.find_all(table_name, selector, options)
         case :mongo_cursor.rest(res) do
           [] ->
             []

--- a/lib/mongoex/server.ex
+++ b/lib/mongoex/server.ex
@@ -28,8 +28,18 @@ defmodule Mongoex.Server do
     execute(fn() -> :mongo.find_one(table, selector) end)
   end
 
-  def find_all(table, selector) do
-    execute(fn() -> :mongo.find(table,selector) end)
+  def find_all(table, selector, options // []) do
+    skip = options[:skip]
+    if skip == nil do
+      skip = 0
+    end
+
+    batch_size = options[:batch_size]
+    if batch_size == nil do
+      batch_size = 0
+    end
+
+    execute(fn() -> :mongo.find(table, selector, {}, skip, batch_size) end)
   end
 
   def count(table, selector) do


### PR DESCRIPTION
Just as the topic says - it's now possible to fetch only portions of the collection :).
