### PR TITLE
Simple synchronous authentication added

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ User[_id: {<<80,130,218,110,117,35,125,79,90,0,0,1>>}, name: "mururu", sex: :mal
 iex> mururu.destroy
 :ok
 ```
+
+You can authenticate by passing username and password options in the setup.
+
+Mongoex can maintain a pool of connections that are created on server start. By default only one connction is created but you can change this by passing a pool option. If all connections are in use then a DB function will return ```{:error, :no_available_connections}
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ iex> mururu.destroy
 :ok
 ```
 
+## Options
+
 You can authenticate by passing username and password options in the setup.
 
-Mongoex can maintain a pool of connections that are created on server start. By default only one connction is created but you can change this by passing a pool option. If all connections are in use then a DB function will return ```{:error, :no_available_connections}
+Mongoex can maintain a pool of connections that are created on server start. By default only one connction is created but you can change this by passing a pool option. If all connections are in use then a DB function will return
 
+```elixir
+{:error, :no_available_connections}
+```


### PR DESCRIPTION
Simple authentication added by allowing username and password config options. These are checked for not nil in Mongoex.Server.execute and if populated an auth function is passed to mongo_do before the user fun passed to execute.

Additionally, the table_name is generated differently because of possible module nesting.
